### PR TITLE
Use V9 Submitter & Creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - added `balrogscript.constants` module
 - added support for `submit-toplevel` and `schedule` actions, for releases.
+- switched to V9 Creator and Submitter for releases
 
 ### Changed
 - the `schema_file` string is now a `schema_files` dict in config.

--- a/balrogscript/script.py
+++ b/balrogscript/script.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 # create_locale_submitter {{{1
 def create_locale_submitter(e, balrog_auth, config):
-    from balrog.submitter.cli import NightlySubmitterV4, ReleaseSubmitterV4  # noqa: E402
+    from balrog.submitter.cli import NightlySubmitterV4, ReleaseSubmitterV9  # noqa: E402
     auth = balrog_auth
 
     if "tc_release" in e:
@@ -29,7 +29,7 @@ def create_locale_submitter(e, balrog_auth, config):
 
         complete_info = e['completeInfo']
         partial_info = e.get('partialInfo')
-        submitter = ReleaseSubmitterV4(api_root=config['api_root'], auth=auth,
+        submitter = ReleaseSubmitterV9(api_root=config['api_root'], auth=auth,
                                        dummy=config['dummy'])
 
         data = {

--- a/balrogscript/script.py
+++ b/balrogscript/script.py
@@ -119,8 +119,8 @@ def schedule(task, config, balrog_auth):
 
 # submit_toplevel {{{1
 def create_creator(**kwargs):
-    from balrog.submitter.cli import ReleaseCreatorV4
-    return ReleaseCreatorV4(**kwargs)
+    from balrog.submitter.cli import ReleaseCreatorV9
+    return ReleaseCreatorV9(**kwargs)
 
 
 def create_pusher(**kwargs):

--- a/balrogscript/test/test_script.py
+++ b/balrogscript/test/test_script.py
@@ -20,7 +20,7 @@ from balrog.submitter.cli import (
     ReleaseCreatorV9,
     ReleasePusher,
     ReleaseScheduler,
-    ReleaseSubmitterV4,
+    ReleaseSubmitterV9,
 )  # noqa: E402
 
 logging.basicConfig()
@@ -55,11 +55,11 @@ def test_create_locale_submitter_release_style(config, release_manifest):
     balrog_auth = (None, None)
 
     submitter, release = bscript.create_locale_submitter(release_manifest[0], balrog_auth, config)
-    assert isinstance(submitter, ReleaseSubmitterV4)
+    assert isinstance(submitter, ReleaseSubmitterV9)
 
     release_manifest[0].pop("partialInfo", None)
     submitter, release = bscript.create_locale_submitter(release_manifest[0], balrog_auth, config)
-    assert isinstance(submitter, ReleaseSubmitterV4)
+    assert isinstance(submitter, ReleaseSubmitterV9)
 
     release_manifest[0].pop("tc_release", None)
     with pytest.raises(RuntimeError):

--- a/balrogscript/test/test_script.py
+++ b/balrogscript/test/test_script.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.join(
 ))
 from balrog.submitter.cli import (
     NightlySubmitterV4,
-    ReleaseCreatorV4,
+    ReleaseCreatorV9,
     ReleasePusher,
     ReleaseScheduler,
     ReleaseSubmitterV4,
@@ -161,7 +161,7 @@ def test_create_creator(config):
     balrog_auth = (None, None)
     assert isinstance(
         bscript.create_creator(api_root=config['api_root'], auth=balrog_auth),
-        ReleaseCreatorV4
+        ReleaseCreatorV9
     )
 
 


### PR DESCRIPTION
Support for this is being added to cli.py in https://bugzilla.mozilla.org/show_bug.cgi?id=1431789 - the interface to the classes has not changed.

I'd like to test this with a staging release before it lands in prod.