### PR TITLE
Bump to 2.0.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.1]
+## [3.0.0]
 ### Changed
 - switched to V9 Creator and Submitter for releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.0] - unreleased
+## [2.0.1]
+### Changed
+- switched to V9 Creator and Submitter for releases
+
+## [2.0.0]
 ### Added
 - added `balrogscript.constants` module
 - added support for `submit-toplevel` and `schedule` actions, for releases.
-- switched to V9 Creator and Submitter for releases
 
 ### Changed
 - the `schema_file` string is now a `schema_files` dict in config.

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
     "version": [
-        2,
+        3,
         0,
-        1
+        0
     ],
-    "version_string": "2.0.1"
+    "version_string": "3.0.0"
 }

--- a/version.json
+++ b/version.json
@@ -2,7 +2,7 @@
     "version": [
         2,
         0,
-        0
+        1
     ],
-    "version_string": "2.0.0"
+    "version_string": "2.0.1"
 }


### PR DESCRIPTION
AFAICT, 2.0.0 is already deployed (https://github.com/mozilla/build-puppet/blob/e0fcbd500fff201789bef4a93badf28e63016e09/modules/balrog_scriptworker/manifests/init.pp#L68)