### PR TITLE
Runs autoformatter on json files

### DIFF
--- a/balrogscript/test/data/hardcoded_config.json
+++ b/balrogscript/test/data/hardcoded_config.json
@@ -1,30 +1,44 @@
 {
-"artifact_dir": "balrogscript/data/balrog_task_schema.json",
- "disable_certs": false,
- "dummy": false,
- "schema_files": {
-  "submit-locale": "balrogscript/data/balrog_submit-locale_schema.json",
-  "submit-toplevel": "balrogscript/data/balrog_submit-toplevel_schema.json",
-  "schedule": "balrogscript/data/balrog_schedule_schema.json"
- },
- "taskcluster_scope_prefix": "project:releng:balrog:",
- "server_config": {"dep": {"allowed_channels": ["nightly",
-                                                "release",
-                                                "beta",
-                                                "etc"],
-                           "api_root": "BALROG_API_ROOT",
-                           "balrog_password": "BALROG_PASSWORD",
-                           "balrog_username": "BALROG_USERNAME"},
-                   "nightly": {"allowed_channels": ["nightly"],
-                               "api_root": "BALROG_API_ROOT",
-                               "balrog_password": "BALROG_PASSWORD",
-                               "balrog_username": "BALROG_USERNAME"},
-                   "release": {"allowed_channels": ["release",
-                                                    "release-localtest",
-                                                    "release-cdntest"],
-                               "api_root": "BALROG_API_ROOT",
-                               "balrog_password": "BALROG_PASSWORD",
-                               "balrog_username": "BALROG_USERNAME"}},
- "verbose": true,
- "work_dir": "balrogscript/test/test_work_dir"
+    "artifact_dir": "balrogscript/data/balrog_task_schema.json",
+    "disable_certs": false,
+    "dummy": false,
+    "schema_files": {
+        "submit-locale": "balrogscript/data/balrog_submit-locale_schema.json",
+        "submit-toplevel": "balrogscript/data/balrog_submit-toplevel_schema.json",
+        "schedule": "balrogscript/data/balrog_schedule_schema.json"
+    },
+    "taskcluster_scope_prefix": "project:releng:balrog:",
+    "server_config": {
+        "dep": {
+            "allowed_channels": [
+                "nightly",
+                "release",
+                "beta",
+                "etc"
+            ],
+            "api_root": "BALROG_API_ROOT",
+            "balrog_password": "BALROG_PASSWORD",
+            "balrog_username": "BALROG_USERNAME"
+        },
+        "nightly": {
+            "allowed_channels": [
+                "nightly"
+            ],
+            "api_root": "BALROG_API_ROOT",
+            "balrog_password": "BALROG_PASSWORD",
+            "balrog_username": "BALROG_USERNAME"
+        },
+        "release": {
+            "allowed_channels": [
+                "release",
+                "release-localtest",
+                "release-cdntest"
+            ],
+            "api_root": "BALROG_API_ROOT",
+            "balrog_password": "BALROG_PASSWORD",
+            "balrog_username": "BALROG_USERNAME"
+        }
+    },
+    "verbose": true,
+    "work_dir": "balrogscript/test/test_work_dir"
 }

--- a/config_example.json
+++ b/config_example.json
@@ -54,5 +54,5 @@
                 "esr-localtest", "esr-cdntest"
             ]
         }
-    },
+    }
 }

--- a/docker/config.json
+++ b/docker/config.json
@@ -1,4 +1,5 @@
-{   "provisioner_id": "test-dummy-provisioner",
+{
+    "provisioner_id": "test-dummy-provisioner",
     "worker_group": "test-dummy-workers",
     "worker_type": "dummy-worker-francis",
     "work_dir": "/app/work",
@@ -6,9 +7,13 @@
     "artifact_dir": "/app/artifacts",
     "artifact_expiration_hours": 24,
     "artifact_upload_timeout": 1200,
-    "task_script": ["/app/py2/bin/python","/app/bin/balrogscript",
-                    "--taskdef","/app/work/task.json",
-                    "--verbose"],
+    "task_script": [
+        "/app/py2/bin/python",
+        "/app/bin/balrogscript",
+        "--taskdef",
+        "/app/work/task.json",
+        "--verbose"
+    ],
     "task_max_timeout": 1200,
     "verbose": true,
     "poll_interval": 10,


### PR DESCRIPTION
`hardcoded_config.json`'s formatting was throwing me off, so I ensured that it was 4-space-indented like the rest of our JSON files in our $scripts. Also removed a stray comma hiding in one of the files.

(of course) feel free to reject this PR, especially if there's a special convention/benefit behind the original format