### PR TITLE
Removes task schema from example config, adds to default config

### DIFF
--- a/balrogscript/script.py
+++ b/balrogscript/script.py
@@ -246,6 +246,7 @@ def setup_config(config_path):
 
 # main {{{1
 def main(config_path=None):
+    # TODO use scriptworker's sync_main(...)
     config = setup_config(config_path)
     setup_logging(config['verbose'])
 

--- a/balrogscript/script.py
+++ b/balrogscript/script.py
@@ -3,6 +3,7 @@
 from copy import deepcopy
 import json
 import logging
+import os
 import sys
 
 from redo import retry  # noqa: E402
@@ -231,7 +232,15 @@ def setup_config(config_path):
             usage()
         config_path = sys.argv[1]
 
-    config = load_config(config_path)
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    config = {
+        'schema_files': {
+            'submit-locale': os.path.join(data_dir, 'balrog_submit-locale_schema.json'),
+            'submit-toplevel': os.path.join(data_dir, 'balrog_submit-toplevel_schema.json'),
+            'schedule': os.path.join(data_dir, 'balrog_schedule_schema.json')
+        },
+    }
+    config.update(load_config(config_path))
     return config
 
 

--- a/balrogscript/test/data/hardcoded_config.json
+++ b/balrogscript/test/data/hardcoded_config.json
@@ -2,11 +2,6 @@
     "artifact_dir": "balrogscript/data/balrog_task_schema.json",
     "disable_certs": false,
     "dummy": false,
-    "schema_files": {
-        "submit-locale": "balrogscript/data/balrog_submit-locale_schema.json",
-        "submit-toplevel": "balrogscript/data/balrog_submit-toplevel_schema.json",
-        "schedule": "balrogscript/data/balrog_schedule_schema.json"
-    },
     "taskcluster_scope_prefix": "project:releng:balrog:",
     "server_config": {
         "dep": {

--- a/config_example.json
+++ b/config_example.json
@@ -2,12 +2,6 @@
     "work_dir": "/tmp/work_dir",
     "artifact_dir": "/tmp/artifact_dir",
 
-    "schema_files": {
-        "submit-locale": "balrogscript/data/balrog_submit-locale_schema.json",
-        "submit-toplevel": "balrogscript/data/balrog_submit-toplevel_schema.json",
-        "schedule": "balrogscript/data/balrog_schedule_schema.json"
-    },
-
     "dummy": false,
     "verbose": true,
     "disable_certs": false,


### PR DESCRIPTION
See [the related `scriptworker` bug](https://github.com/mozilla-releng/scriptworker/issues/287)